### PR TITLE
Add missing title label

### DIFF
--- a/docs/source/introductions/overview.ipynb
+++ b/docs/source/introductions/overview.ipynb
@@ -4,6 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Overview\n",
+    "\n",
+    "Get acquainted with ahlive!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### easy as 1-2-3-4\n",
     "With just a few lines of code, create a stimulating animation!"
    ]


### PR DESCRIPTION
Quick start titles should be under overview